### PR TITLE
Add impala-shell options and request pool environment variables

### DIFF
--- a/impala-compute-stats.sh
+++ b/impala-compute-stats.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 source tpcds-env.sh
 
-impala-shell -d $TPCDS_DBNAME <<EOF
+impala-shell $IMPALA_SHELL_OPTS -d $TPCDS_DBNAME <<EOF
+set REQUEST_POOL=$REQUEST_POOL;
 compute stats date_dim;
 compute stats time_dim;
 compute stats customer;

--- a/impala-create-external-tables.sh
+++ b/impala-create-external-tables.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 source tpcds-env.sh
 
-impala-shell -q "create database $TPCDS_DBNAME;"
+impala-shell $IMPALA_SHELL_OPTS -q "create database $TPCDS_DBNAME;"
 
-impala-shell -d $TPCDS_DBNAME <<EOF
+impala-shell $IMPALA_SHELL_OPTS -d $TPCDS_DBNAME <<EOF
 create external table et_store_sales
 (
   ss_sold_date_sk           bigint,

--- a/impala-load-dims.sh
+++ b/impala-load-dims.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 source tpcds-env.sh
 
-impala-shell -d $TPCDS_DBNAME <<EOF
+impala-shell $IMPALA_SHELL_OPTS -d $TPCDS_DBNAME <<EOF
+set REQUEST_POOL=$REQUEST_POOL;
 create table date_dim like et_date_dim stored as parquetfile;
 insert overwrite table date_dim select * from et_date_dim;
 

--- a/impala-load-store_sales.sh
+++ b/impala-load-store_sales.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 source tpcds-env.sh
 
-impala-shell -d ${TPCDS_DBNAME} -q "
+impala-shell $IMPALA_SHELL_OPTS -d ${TPCDS_DBNAME} -q "
+set REQUEST_POOL=$REQUEST_POOL;
 drop table if exists store_sales;
 
 create table store_sales

--- a/load-store-sales.py
+++ b/load-store-sales.py
@@ -17,7 +17,8 @@ TPCDS_DB = os.getenv('TPCDS_DBNAME')
 IMPALA_SHELL_OPTS = os.getenv('IMPALA_SHELL_OPTS')
 if IMPALA_SHELL_OPTS == None: IMPALA_SHELL_OPTS = ""
 REQUEST_POOL = os.getenv('REQUEST_POOL')
-IMPALAD = socket.getfqdn()
+IMPALAD = os.getenv('IMPALAD')
+if IMPALAD == None: IMPALAD = socket.getfqdn()
 LOAD_FILE = "load_store_sales_tmp.sql"
 
 def get_mem_limit():

--- a/load-store-sales.py
+++ b/load-store-sales.py
@@ -14,6 +14,9 @@ from math import ceil
 from subprocess import call
 
 TPCDS_DB = os.getenv('TPCDS_DBNAME')
+IMPALA_SHELL_OPTS = os.getenv('IMPALA_SHELL_OPTS')
+if IMPALA_SHELL_OPTS == None: IMPALA_SHELL_OPTS = ""
+REQUEST_POOL = os.getenv('REQUEST_POOL')
 IMPALAD = socket.getfqdn()
 LOAD_FILE = "load_store_sales_tmp.sql"
 
@@ -75,9 +78,10 @@ def _main():
   queries = generate_queries(ss_sold_dates)
   with open(LOAD_FILE, 'w') as f:
     f.write('USE {0};\n'.format(TPCDS_DB))
+    f.write('set REQUEST_POOL={0};\n'.format(REQUEST_POOL))
     f.write(';\n'.join(queries))
   try:
-    os.system('impala-shell -f {0}'.format(LOAD_FILE))
+    os.system('impala-shell {0} -f {1}'.format(IMPALA_SHELL_OPTS, LOAD_FILE))
   except Exception, e:
     print "Data Loading failed: %s" % e
   finally:
@@ -85,5 +89,6 @@ def _main():
 
 if __name__ == "__main__":
   assert TPCDS_DB, "The TPCDS_DBNAME environment variable is required"
+  assert REQUEST_POOL, "The REQUEST_POOL environment variable is required"
   assert get_mem_limit() > 2.0, "The impalad's memory limit is too low"
   _main()

--- a/tpcds-env.sh
+++ b/tpcds-env.sh
@@ -17,3 +17,11 @@ export DSDGEN_TOTAL_THREADS=$((DSDGEN_NODES * DSDGEN_THREADS_PER_NODE))
 
 # the name for the tpcds database
 export TPCDS_DBNAME=tpcds_parquet
+
+# this is used to set additional options for impala-shell
+# -k : Enable kerberos authentication
+# -i <hostname> : Specify the impalad host, useful if you're using a load balancer
+export IMPALA_SHELL_OPTS=""
+
+# Set the REQUEST_POOL to use for Impala queries
+export REQUEST_POOL="default"

--- a/tpcds-env.sh
+++ b/tpcds-env.sh
@@ -25,3 +25,6 @@ export IMPALA_SHELL_OPTS=""
 
 # Set the REQUEST_POOL to use for Impala queries
 export REQUEST_POOL="default"
+
+# hostname of an impalad instance to connect to from master node
+IMPALAD=""


### PR DESCRIPTION
I've added a couple of changes that allow users to more easily adapt the scripts to their environment. In cases where you need to add options to impala-shell in order for the scripts to work I have added an environment variable IMPALA_SHELL_OPTS to tpcds-env.sh and updated the scripts so that all invocations of impala-shell add this to the command line. This allows use on clusters with security features enabled (TLS, kerberos, LDAP authentication) for example or where Impala is configured to use a load balancer.

I've also explicitly set REQUEST_POOL in the scripts so that Impala jobs can be submitted to a given request pool. The default value is "default" so running clusters without more complex pool configurations will work as before.
